### PR TITLE
:heavy_plus_sign: Add missing dependencies

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 #=================================================
 
 # dependencies used by the app
-pkg_dependencies="acl python3 python3-dev python3-pip python3-venv postgresql postgresql-contrib libpq-dev redis-server libldap2-dev libsasl2-dev"
+pkg_dependencies="acl libffi-dev libjpeg-dev libwebp-dev python3 python3-dev python3-pip python3-venv postgresql postgresql-contrib libpq-dev redis-server libldap2-dev libsasl2-dev"
 
 #=================================================
 # PERSONAL HELPERS


### PR DESCRIPTION
## Problem

The dependency list was missing some packages listed as dependencies by gpodder. This caused errors while setting up the python virtualenv.

## Solution

Add the missing dependencies (libffi-dev libjpeg-dev libwebp-dev) to pkg_dependencies.
fixes #21 

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
