### PR TITLE
:bug: Use django collectstatic

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -7,7 +7,7 @@ location /media {
 }
 
 location /static/ {
-  alias __INSTALL_DIR__/static/;
+  alias __INSTALL_DIR__/staticfiles/;
 }
 
 location /logo {
@@ -43,14 +43,6 @@ location @proxy_to_app {
   proxy_http_version 1.1;
   proxy_set_header Upgrade $http_upgrade;
   proxy_set_header Connection "upgrade";
-}
-
-location /media/admin/ {
-  alias __INSTALL_DIR__/venv/lib/python3.7/site-packages/django/contrib/admin/static/admin/;
-}
-
-location /static/admin/ {
-  alias __INSTALL_DIR__/venv/lib/python3.7/site-packages/django/contrib/admin/static/admin/;
 }
 
 location ~ /(favicon.ico|favicon.png|robots.txt|clientconfig.json) {

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -32,6 +32,13 @@ function set_up_virtualenv {
 	ynh_exec_warn_less ynh_exec_as "$app" "$install_dir/venv/bin/pip" --cache-dir "$install_dir/.cache/pip" install -U --requirement "$install_dir/requirements-ynh.txt"
 }
 
+function collect_static {
+	pushd "$install_dir"
+		chown -R "$app:$app" "$install_dir"
+		ynh_exec_warn_less ynh_exec_as "$app" "$install_dir/venv/bin/envdir" "$env_path" "$install_dir/venv/bin/python" "$install_dir/manage.py" collectstatic --noinput
+	popd
+}
+
 function initialize_db {
 	perform_db_migrations
 	ynh_exec_warn_less ynh_exec_as "$app" "$install_dir/venv/bin/envdir" "$env_path" "$install_dir/venv/bin/python" "$install_dir/sources/manage.py" createsuperuser --username "$admin" --email "$admin_email" --noinput -v 0

--- a/scripts/install
+++ b/scripts/install
@@ -54,6 +54,10 @@ ynh_script_progression --message="Initializing Python virtualenv..." --weight=20
 
 set_up_virtualenv
 
+ynh_script_progression --message="Collecting static..."
+
+collect_static
+
 #=================================================
 # INITIALIZE DATABASE
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -87,6 +87,10 @@ ynh_script_progression --message="Upgrading Python virtualenv..." --weight=2
 
 set_up_virtualenv
 
+ynh_script_progression --message="Collecting static..."
+
+collect_static
+
 #=================================================
 # PERFORM DATABASE MIGRATIONS
 #=================================================


### PR DESCRIPTION
## Problem

- The yunohost app was using the development locations for static files. As some of these had the python version in their path, but no specific python version was specified for the app, some of the paths could end up using "pythonX.Y" when the real path was "pythonX.Z".

## Solution

- Add a function calling django collectstatic action
- Call said function in some of the app scripts (install, upgrade and restore)
- Serve all static files from the new location
(fix #23 )

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
